### PR TITLE
feat: support FOFA_EMAIL/FOFA_KEY environment variables in mcp.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,25 @@ Cursor 对 MCP 的支持非常完善，配置好后，你可以直接在 Compose
         * 例如：`python3.10`
     - **Args**: `你的脚本绝对路径`
         * 例如：`/Users/ka/Downloads/fofamap/fofa/mcp_server.py`
+    - **Env** (可选): `FOFA_EMAIL` 和 `FOFA_KEY`
+        * 支持直接在 mcp.json 的 `env` 中配置 FOFA 凭据，**优先级高于** `config/settings.yaml` 中的 `email` / `key`，适合不想把凭据写进项目配置文件的场景。
+
+    完整的 mcp.json 参考示例：
+
+    ```json
+    {
+      "mcpServers": {
+        "fofamap-v2": {
+          "command": "python3.10",
+          "args": ["/Users/ka/Downloads/fofamap/fofa/mcp_server.py"],
+          "env": {
+            "FOFA_EMAIL": "your_email@example.com",
+            "FOFA_KEY": "your_fofa_api_key"
+          }
+        }
+      }
+    }
+    ```
 
 <!-- 这是一张图片，ocr 内容为： -->
 ![](https://cdn.nlark.com/yuque/0/2026/png/12839102/1767953312691-9b0133cf-fc4c-47d7-82d8-a2bf55d2efec.png)
@@ -594,6 +613,7 @@ LM Studio 0.3.0+ 版本开始支持 MCP。这允许你用本地的 DeepSeek 或 
     - **Command**: `你的Python解释器绝对路径`
     - **Args**: `你的脚本绝对路径` (注意：LM Studio 有时需要把 args 分开填，或者填在一个框里，视版本而定)。
         * _建议形式_: `["/Users/ka/.../mcp_server.py"]`
+    - **Env** (可选): 同样支持 `FOFA_EMAIL` / `FOFA_KEY` 环境变量，用法见上文 Cursor 的 mcp.json 示例。
 
 <!-- 这是一张图片，ocr 内容为： -->
 ![](https://cdn.nlark.com/yuque/0/2026/png/12839102/1767954026399-f53295dc-ac1e-4101-9f54-dc87fd438ea5.png)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 import yaml
 from pydantic import BaseModel, Field
 from pathlib import Path
@@ -54,11 +56,22 @@ def load_config() -> Config:
         with open(config_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
             # 现在 Config(**data) 会正确映射 base_url 和 model 了
-            return Config(**data)
+            config = Config(**data)
     except Exception as e:
         print(f"[!] 配置文件解析失败: {e}")
         print("[!] 请检查 config/settings.yaml 的格式是否正确")
         exit(1)
+
+    # 环境变量优先级高于 settings.yaml，便于在 mcp.json 的 "env" 中直接配置凭据：
+    #   "env": { "FOFA_EMAIL": "your_email@example.com", "FOFA_KEY": "your_fofa_api_key" }
+    env_email = os.environ.get("FOFA_EMAIL")
+    env_key = os.environ.get("FOFA_KEY")
+    if env_email:
+        config.userinfo.email = env_email
+    if env_key:
+        config.userinfo.key = env_key
+
+    return config
 
 
 # 初始化全局单例配置


### PR DESCRIPTION
## 背景 (Motivation)

目前 FofaMap 的 MCP 服务只能通过 `config/settings.yaml` 配置 FOFA 凭据，不支持在 `mcp.json` 的 `env` 字段中传入。这带来两个不便：

1. 不符合 MCP 生态的常见做法（大多数 MCP Server 都支持通过 `env` 注入凭据）；
2. 凭据必须写进项目目录下的配置文件，容易随项目一起被误提交，且在多项目共享同一份 FofaMap 时不够灵活。

## 改动内容 (Changes)

- **`config/__init__.py`**：在加载 `settings.yaml` 之后，读取环境变量 `FOFA_EMAIL` 和 `FOFA_KEY` 并覆盖 `userinfo.email` / `userinfo.key`。环境变量**优先级高于** yaml 配置；未设置环境变量时行为与之前完全一致（向后兼容）。由于 CLI 与 MCP 共用 `settings` 单例，CLI 模式下同样生效。
- **`README.md`**：在 Cursor / LM Studio 的 MCP 集成章节中补充 `env` 配置说明，并给出完整的 `mcp.json` 参考示例：

```json
{
  "mcpServers": {
    "fofamap-v2": {
      "command": "python3.10",
      "args": ["/path/to/mcp_server.py"],
      "env": {
        "FOFA_EMAIL": "your_email@example.com",
        "FOFA_KEY": "your_fofa_api_key"
      }
    }
  }
}
```

## 测试 (Testing)

已验证以下三种场景：

| 场景 | 结果 |
| --- | --- |
| 未设置环境变量 | 使用 `settings.yaml` 中的 email/key（行为不变） |
| 设置 `FOFA_EMAIL` + `FOFA_KEY` | 覆盖 yaml 中的对应值 |
| 仅设置其中一个环境变量 | 只覆盖对应字段，另一字段仍取 yaml 值 |

## 兼容性

完全向后兼容：不设置环境变量时，加载逻辑与改动前一致，`settings.yaml` 仍是必需的（其余配置项仍从 yaml 读取）。
